### PR TITLE
 make "endswith()" case insensitive for file extension checks

### DIFF
--- a/src/CutListSupport.py
+++ b/src/CutListSupport.py
@@ -92,7 +92,7 @@ class CutList():
 		name = None
 		if path:
 			#TODO very slow
-			if path.endswith(".iso"):
+			if path.lower().endswith(".iso"):
 				if not self.iso:
 					self.iso = IsoSupport(path)
 				name = self.iso and self.iso.getIsoName()

--- a/src/IsoFileSupport.py
+++ b/src/IsoFileSupport.py
@@ -37,7 +37,7 @@ class IsoSupport():
 
 	def __newPath(self, path):
 		if path:
-			if path.endswith(".iso"):
+			if path.lower().endswith(".iso"):
 				if self.iso_file == path:
 					# Same file
 					pass
@@ -64,7 +64,7 @@ class IsoSupport():
 			# Attention: Read can be very slow !!!
 			name = ""
 			path = self.iso_file
-			if path and os.path.exists(path) and path.endswith(".iso"):
+			if path and os.path.exists(path) and path.lower().endswith(".iso"):
 				mtime = os.path.getmtime(path)
 				if self.iso_mtime == mtime:
 					# File has not changed

--- a/src/MovieCenter.py
+++ b/src/MovieCenter.py
@@ -189,7 +189,7 @@ def getPlayerService(path, name="", ext=None):
 		#QUESTION Is the special name handling really necessary
 		if service:
 			# Copied from dvd player
-			if path.endswith("/VIDEO_TS") or path.endswith("/"):
+			if path.lower().endswith("/video_ts") or path.endswith("/"):
 				names = service.toString().rsplit("/",3)
 				if names[2].startswith("Disk ") or names[2].startswith("DVD "):
 					#TEST name = str(names[1]) + " - " + str(names[2])
@@ -213,7 +213,7 @@ def getMovieNameWithoutExt(moviename=""):
 	if config.EMC.movie_show_format.value:
 		for rem in extVideo:
 			rem = rem.replace("."," ")
-			if moviename.endswith(rem):
+			if moviename.lower().endswith(rem):
 				moviename = moviename[:-len(rem)]
 				break
 	return moviename

--- a/src/MovieRetitle.py
+++ b/src/MovieRetitle.py
@@ -137,7 +137,7 @@ class MovieRetitle(Screen, ConfigListScreen):
 
 	def setTitleDescr(self, service, title, descr):
 		#TODO Use MetaSupport class
-		if service.getPath().endswith(".ts"):
+		if service.getPath().lower().endswith(".ts"):
 			meta_file = service.getPath() + ".meta"
 		else:
 			meta_file = service.getPath() + ".ts.meta"

--- a/src/RecordingsControl.py
+++ b/src/RecordingsControl.py
@@ -32,7 +32,7 @@ from DelayedFunction import DelayedFunction
 def getRecording(filename):
 	try:
 		if filename[0] == "/": 			filename = os.path.basename(filename)
-		if filename.endswith(".ts"):	filename = filename[:-3]
+		if filename.lower().endswith(".ts"):	filename = filename[:-3]
 
 		for timer in NavigationInstance.instance.RecordTimer.timer_list:
 			try: timer.Filename
@@ -153,7 +153,7 @@ class RecordingsControl:
 	def isRecording(self, filename):
 		try:
 			if filename[0] == "/": 			filename = os.path.basename(filename)
-			if filename.endswith(".ts"):	filename = filename[:-3]
+			if filename.lower().endswith(".ts"):	filename = filename[:-3]
 			return filename in self.recDict
 		except Exception, e:
 			emcDebugOut("[emcRC] isRecording exception:\n" + str(e))
@@ -162,7 +162,7 @@ class RecordingsControl:
 	def isRemoteRecording(self, filename):
 		try:
 			if filename[0] == "/": 			filename = os.path.basename(filename)
-			if filename.endswith(".ts"):	filename = filename[:-3]
+			if filename.lower().endswith(".ts"):	filename = filename[:-3]
 			return filename in self.recRemoteList
 		except Exception, e:
 			emcDebugOut("[emcRC] isRemoteRecording exception:\n" + str(e))
@@ -171,7 +171,7 @@ class RecordingsControl:
 	def stopRecording(self, filename):
 		try:
 			if filename[0] == "/":			filename = os.path.basename(filename)
-			if filename.endswith(".ts"):	filename = filename[:-3]
+			if filename.lower().endswith(".ts"):	filename = filename[:-3]
 			if filename in self.recDict:
 				for timer in NavigationInstance.instance.RecordTimer.timer_list:
 					if timer.isRunning() and not timer.justplay and timer.Filename.find(filename)>=0:
@@ -188,7 +188,7 @@ class RecordingsControl:
 
 	def isCutting(self, filename):
 		try:
-			if filename.endswith("_.ts"):
+			if filename.lower().endswith("_.ts"):
 				if not os.path.exists(filename[:-2]+"eit"):
 					return True
 			return False
@@ -198,8 +198,8 @@ class RecordingsControl:
 
 	def fixTimerPath(self, old, new):
 		try:
-			if old.endswith(".ts"):	old = old[:-3]
-			if new.endswith(".ts"):	new = new[:-3]
+			if old.lower().endswith(".ts"):	old = old[:-3]
+			if new.lower().endswith(".ts"):	new = new[:-3]
 			for timer in NavigationInstance.instance.RecordTimer.timer_list:
 				if timer.isRunning() and not timer.justplay and timer.Filename == old:
 					timer.dirname = os.path.dirname(new) + "/"
@@ -243,7 +243,7 @@ class RecordingsControl:
 			if config.EMC.folder.value and os.path.exists(config.EMC.folder.value):
 				for x in os.listdir(config.EMC.folder.value):
 					path = os.path.join(config.EMC.folder.value, x)
-					if x.endswith(".rec") and path != self.recFile:
+					if x.lower().endswith(".rec") and path != self.recFile:
 						recf = open( path, "rb" )
 						self.recRemoteList += pickle.load(recf)
 		except Exception, e:


### PR DESCRIPTION
In several locations the file extensions were checked case sensitive.
This failed on files like "movie.ISO" which could lead to weird side
effects.

