### PR TITLE
Fix EnhancedMovieCenteruniq.pot

### DIFF
--- a/po/EnhancedMovieCenter.pot
+++ b/po/EnhancedMovieCenter.pot
@@ -69,10 +69,6 @@ msgid "Set path to save the folder Cover:"
 msgstr ""
 
 #: EMCCoverSearch.py
-msgid "Search filter for matching existing terms in the title:"
-msgstr ""
-
-#: EMCCoverSearch.py
 msgid "Search Results per Search Site (without counting cover range):"
 msgstr ""
 


### PR DESCRIPTION
| msguniq -o EnhancedMovieCenteruniq.pot EnhancedMovieCenter.pot
| EnhancedMovieCenter.pot:72: duplicate message definition...
| EnhancedMovieCenter.pot:61: ...this is the location of the first definition
| msgmerge: found 1 fatal error