### PR TITLE
MovieRetitle.py rename of directory works

### DIFF
--- a/src/MovieRetitle.py
+++ b/src/MovieRetitle.py
@@ -59,8 +59,8 @@ class MovieRetitle(Screen, ConfigListScreenExt):
 		self.service = service
 		info = self.serviceHandler.info(service)
 		path = service.getPath()
-		# self.is_dir = service.flags & eServiceReference.mustDescent  // old
-		self.is_dir = os.path.isdir(path)  // new
+		# self.is_dir = service.flags & eServiceReference.mustDescent  # old
+		self.is_dir = os.path.isdir(path)  # new
 		self["Path"] = Label(_("Location:") + ' ' + os.path.dirname(os.path.splitext(path)[0]))
 		if self.is_dir:
 			self.original_file = service.getName()

--- a/src/MovieRetitle.py
+++ b/src/MovieRetitle.py
@@ -57,9 +57,10 @@ class MovieRetitle(Screen, ConfigListScreenExt):
 
 	def buildSetup(self, service):
 		self.service = service
-		self.is_dir = service.flags & eServiceReference.mustDescent
 		info = self.serviceHandler.info(service)
 		path = service.getPath()
+		# self.is_dir = service.flags & eServiceReference.mustDescent  // old
+		self.is_dir = os.path.isdir(path)  // new
 		self["Path"] = Label(_("Location:") + ' ' + os.path.dirname(os.path.splitext(path)[0]))
 		if self.is_dir:
 			self.original_file = service.getName()


### PR DESCRIPTION
If the rename function was executed on a directory the dialog showed the fields for a file. 'self.is_dir' was set to false, now it is determined by looking at 'path'.